### PR TITLE
Added support for areas

### DIFF
--- a/Core/Modules/OutputSubstitution/OutputSubstitutionExecutor.cs
+++ b/Core/Modules/OutputSubstitution/OutputSubstitutionExecutor.cs
@@ -12,7 +12,7 @@ namespace Moth.Core.Modules.OutputSubstitution
 {
     internal class OutputSubstitutionExecutor : IExecutor
     {
-        private static readonly Regex PartialAction = new Regex(@"<%\s*?Moth\.RenderAction\((['""])(?<action>\w+)\1,\1(?<controller>\w+)\1\);\s*%>", RegexOptions.Compiled);
+        private static readonly Regex PartialAction = new Regex(@"<%\s*?Moth\.RenderAction\((['""])(?<action>\w+)\1,\1(?<controller>\w+)\1,\1(?<area>\w+)\1\);\s*%>", RegexOptions.Compiled);
 
         public string Replace(HttpContextBase httpContext, ControllerContext controllerContext, string input)
         {
@@ -26,6 +26,15 @@ namespace Moth.Core.Modules.OutputSubstitution
             {
                 string action = m.Groups["action"].Value;
                 string controller = m.Groups["controller"].Value;
+                object routeValues = null;
+                if (m.Groups["area"].Success)
+                {
+                    string area = m.Groups["area"].Value;
+                    if(!string.IsNullOrEmpty(area))
+                    {
+                        routeValues = new {area};
+                    }
+                }
 
                 using (var ms = new MemoryStream())
                 using (var tw = new StreamWriter(ms))
@@ -34,7 +43,7 @@ namespace Moth.Core.Modules.OutputSubstitution
 
                     Stopwatch actionSw = Stopwatch.StartNew();
 
-                    html.RenderAction(action, controller);
+                    html.RenderAction(action, controller, routeValues);
 
                     actionSw.Stop();
                     Trace.Write(string.Format("Donut hole: {0} took {1:F2} ms.", action, actionSw.Elapsed.TotalMilliseconds));

--- a/Core/Modules/OutputSubstitution/OutputSubstitutionHelper.cs
+++ b/Core/Modules/OutputSubstitution/OutputSubstitutionHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Web.Mvc;
 using System.Web.Mvc.Html;
+using System.Web.Routing;
 using System.Web.UI;
 using Moth.Core.Helpers;
 using Moth.Core.Providers;
@@ -18,16 +19,22 @@ namespace Moth.Core
             Provider = MothAction.CacheProvider;
         }
 
+
         public static void RenderMothAction<TModel>(this HtmlHelper<TModel> htmlHelper, string actionName, string controllerName)
+        {
+            RenderMothAction(htmlHelper, actionName, controllerName, null);
+        }
+
+        public static void RenderMothAction<TModel>(this HtmlHelper<TModel> htmlHelper, string actionName, string controllerName, string areaName)
         {
             // als pagecaching uberhaupt aanstaat, en de huidige viewcontext schrijft tegen een gemockte writer aan; dan doen we donut.renderAction
             if (htmlHelper.ViewContext.IsMothEnabled())
             {
-                htmlHelper.ViewContext.Writer.Write(string.Format("<% Moth.RenderAction('{0}','{1}'); %>", actionName, controllerName));
+                htmlHelper.ViewContext.Writer.Write(string.Format("<% Moth.RenderAction('{0}','{1}','{2}'); %>", actionName, controllerName, areaName));
             }
             else
             {
-                htmlHelper.RenderAction(actionName, controllerName);
+                htmlHelper.RenderAction(actionName, controllerName, new {area = areaName});
             }
         }
     }


### PR DESCRIPTION
I've added a overload to RenderMothAction to specify the area the controller that the action is part of lives in. This is a fix for issue #11.
